### PR TITLE
c/comparison.py: make docstring a raw string.

### DIFF
--- a/colorspacious/comparison.py
+++ b/colorspacious/comparison.py
@@ -8,7 +8,7 @@ from .conversion import cspace_convert
 
 def deltaE(color1, color2,
            input_space="sRGB1", uniform_space="CAM02-UCS"):
-    """Computes the :math:`\Delta E` distance between pairs of colors.
+    r"""Computes the :math:`\Delta E` distance between pairs of colors.
 
     :param input_space: The space the colors start out in. Can be anything
        recognized by :func:`cspace_convert`. Default: "sRGB1"


### PR DESCRIPTION
The docstring describing the deltaE function contains several mathematical symbols with LaTeX-style syntax, causing python3.12 and newer to throw SyntaxWarning, like reported in issue #32, or like [Debian bug #1085424].  Converting it to raw string prevents attempts to interpret the backslash character as if it were an invalid escape sequence in a C string.

[Debian bug #1085424]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085424